### PR TITLE
Add explicit 'node' to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "files": [],
   "scripts": {
     "mkdirs": "mkdir -p packages && mkdir -p deploys",
-    "fetch": "yarn run mkdirs && scripts/fetch-package.js",
-    "check": "scripts/check-webapp.js",
+    "fetch": "yarn run mkdirs && node scripts/fetch-package.js",
+    "check": "node scripts/check-webapp.js",
     "start": "yarn run check && yarn install:electron && electron .",
     "install:electron": "electron-builder install-app-deps",
     "lint": "eslint src/",


### PR DESCRIPTION
Otherwise they just get run with the windows scripting host
on Windows which does not go so well.