### PR TITLE
Sanitise scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
     "fetch": "yarn run mkdirs && node scripts/fetch-package.js",
     "check": "node scripts/check-webapp.js",
     "start": "yarn run check && yarn install:electron && electron .",
-    "install:electron": "electron-builder install-app-deps",
     "lint": "eslint src/",
-    "build:electron": "yarn run check && electron-builder",
+    "build": "yarn run check && electron-builder",
     "clean": "rimraf webapp dist packages deploys"
   },
   "dependencies": {


### PR DESCRIPTION
 * Remove install:electron - it ran install-app-deps which makes sure
   native deps are installed but the native deps we use don't work
   with electron-builder anyway (they don't use binding.gyp) so this
   does absolutely nothing at all.
 * Rename build:electron to build (there is only one thing to build
   now).