### PR TITLE
Build on 32 bit Windows

### DIFF
--- a/hak/matrix-seshat/build.js
+++ b/hak/matrix-seshat/build.js
@@ -240,6 +240,12 @@ async function buildMatrixSeshat(hakEnv, moduleInfo) {
 
     if (hakEnv.isWin()) {
         env.RUSTFLAGS = '-Ctarget-feature=+crt-static -Clink-args=libcrypto.lib';
+        // Note that in general, you can specify targets in Rust without having to have
+        // the matching toolchain, however for this, cargo gets confused when building
+        // the build scripts since they run on the host, but vcvarsall.bat sets the c
+        // compiler in the path to be the one for the target, so we just use the matching
+        // toolchain for the target architecture which makes everything happy.
+        env.RUSTUP_TOOLCHAIN = hakEnv.arch == 'x64' ? 'stable-x86_64-pc-windows-msvc' : 'stable-i686-pc-windows-msvc';
     }
 
     console.log("Running neon with env", env);

--- a/hak/matrix-seshat/check.js
+++ b/hak/matrix-seshat/check.js
@@ -37,6 +37,7 @@ module.exports = async function(hakEnv, moduleInfo) {
     const tools = [];
     if (hakEnv.isWin()) {
         tools.push(['perl', '--version']); // for openssl configure
+        tools.push(['patch', '--version']); // to patch sqlcipher Makefile.msc
         tools.push(['nmake', '/?']);
     } else {
         tools.push(['make', '--version']);

--- a/hak/matrix-seshat/check.js
+++ b/hak/matrix-seshat/check.js
@@ -34,7 +34,7 @@ module.exports = async function(hakEnv, moduleInfo) {
         });
     }
 
-    const tools = [];
+    const tools = ['python', '--version']; // node-gyp uses python for reasons beyond comprehension
     if (hakEnv.isWin()) {
         tools.push(['perl', '--version']); // for openssl configure
         tools.push(['patch', '--version']); // to patch sqlcipher Makefile.msc

--- a/scripts/hak/hakEnv.js
+++ b/scripts/hak/hakEnv.js
@@ -42,6 +42,17 @@ function getTarget(packageJson) {
     }
 }
 
+function detectArch() {
+    if (process.platform === 'win32') {
+        const targetArch = process.env.VSCMD_ARG_TGT_ARCH;
+        if (targetArch === 'x86') {
+            return 'ia32';
+        } else if (targetArch === 'x64') {
+            return 'x64';
+        }
+    }
+    return process.arch;
+}
 
 module.exports = class HakEnv {
     constructor(prefix, packageJson) {
@@ -50,7 +61,7 @@ module.exports = class HakEnv {
             runtime: getRuntime(packageJson),
             target: getTarget(packageJson),
             platform: process.platform,
-            arch: process.arch,
+            arch: detectArch(),
 
             // paths
             projectRoot: prefix,

--- a/scripts/hak/hakEnv.js
+++ b/scripts/hak/hakEnv.js
@@ -44,6 +44,10 @@ function getTarget(packageJson) {
 
 function detectArch() {
     if (process.platform === 'win32') {
+        // vcvarsall.bat (the script that sets up the environment for
+        // visual studio build tools) sets an env var to tell us what
+        // architecture the active build tools target, so we auto-detect
+        // this.
         const targetArch = process.env.VSCMD_ARG_TGT_ARCH;
         if (targetArch === 'x86') {
             return 'ia32';


### PR DESCRIPTION
A pleasingly small diff to support targeting 32 bit Windows.

Unfortunately also requires https://github.com/neon-bindings/neon/pull/491, so will require:
 * That PR to be merged
 * Neon to be released
 * neon-serde to release a new version that's compatible with neon 0.4.x
 * matrix-seshat to update versions of both the above