### PR TITLE
Add our native modules separately into the files

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,11 @@
     "appId": "im.riot.app",
     "electronVersion": "7.1.3",
     "files": [
-      "node_modules/**",
+      "package.json",
+      {
+        "from": ".hak/hakModules",
+        "to": "node_modules"
+      },
       "src/**"
     ],
     "extraResources": [

--- a/scripts/hak/fetch.js
+++ b/scripts/hak/fetch.js
@@ -105,7 +105,15 @@ async function fetch(hakEnv, moduleInfo) {
     });
 
     // also extract another copy to the output directory at this point
-    // nb. we do not yarn install in the output copy
+    // nb. we do not yarn install in the output copy: we could install in
+    // production mode to get only runtime dependencies and not devDependencies,
+    // but usually native modules come with dependencies that are needed for
+    // building/fetching the native modules (eg. node-pre-gyp) rather than
+    // actually used at runtime: we do not want to bundle these into our app.
+    // We therefore just install no dependencies at all, and accept that any
+    // actual runtime dependencies will have to be added to the main app's
+    // dependencies. We can't tell what dependencies are real runtime deps
+    // and which are just used for native module building.
     await mkdirp(moduleInfo.moduleOutDir);
     await tar.x({
         file: tarballFile,

--- a/scripts/hak/index.js
+++ b/scripts/hak/index.js
@@ -76,7 +76,7 @@ async function main() {
             moduleHakDir: path.join(prefix, 'hak', dep),
             moduleDotHakDir: path.join(hakEnv.dotHakDir, dep),
             moduleBuildDir: path.join(hakEnv.dotHakDir, dep, 'build'),
-            moduleOutDir: path.join(hakEnv.dotHakDir, dep, 'out'),
+            moduleOutDir: path.join(hakEnv.dotHakDir, 'hakModules', dep),
             nodeModuleBinDir: path.join(hakEnv.dotHakDir, dep, 'build', 'node_modules', '.bin'),
             depPrefix: path.join(hakEnv.dotHakDir, dep, 'opt'),
             scripts: {},


### PR DESCRIPTION
And also the package.json which, for reasons I'm not going to spend
the next two hours of my life wading through the electron-builder
source to discover, is no longer automatically included after adding
the files pattern. The node_modules folder is handled automatically
though, so is redundant.

Change the output directory structure so we have one directory with
all the built native modules under that we can just add to the files,
rather than having to add each one separately.

NB. electron-builder add its own filters to node_modules so that only
runtime (ie. not devDependencies) are copied. These seem to apply
even for manually specified path within node_modules. We can copy *to*
the node_modules directory, however...