### PR TITLE
Hopefully enable subpixel font rendering

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -592,6 +592,9 @@ app.on('ready', async () => {
 
     const preloadScript = path.normalize(`${__dirname}/preload.js`);
     mainWindow = global.mainWindow = new BrowserWindow({
+        // https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
+        backgroundColor: '#fff',
+
         icon: iconPath,
         show: false,
         autoHideMenuBar: store.get('autoHideMenuBar', true),


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/12443 points out the
electron eccentricity that the background of a BrowserWindow is
'transparent' (whatever that actually means in practice) by default
which causes subpixel font rendering to be disabled. Set an explicit
background colour as per the faq entry.

Fixes https://github.com/vector-im/riot-web/issues/12443