### PR TITLE
riot-desktop open SSO in browser so user doesn't have to auth twice

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -24,5 +24,20 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+
+    <!-- Entitlements to support the riot:// protocol handler -->
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>riot</string>
+            </array>
+            <key>CFBundleURLName</key>
+            <string>riot-web</string>
+            <key>CFBundleTypeRole</key>
+            <string>None</string>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -24,20 +24,5 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
-
-    <!-- Entitlements to support the riot:// protocol handler -->
-    <key>CFBundleURLTypes</key>
-    <array>
-        <dict>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <string>riot</string>
-            </array>
-            <key>CFBundleURLName</key>
-            <string>riot-web</string>
-            <key>CFBundleTypeRole</key>
-            <string>None</string>
-        </dict>
-    </array>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
     "directories": {
       "output": "dist"
     },
-    "afterSign": "scripts/electron_afterSign.js"
+    "afterSign": "scripts/electron_afterSign.js",
+    "protocols": [{
+      "name": "riot",
+      "schemes": ["riot"]
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "8.0.1",
+    "electronVersion": "8.0.2",
     "files": [
       "package.json",
       {

--- a/scripts/in-docker.sh
+++ b/scripts/in-docker.sh
@@ -2,7 +2,7 @@
 
 docker inspect riot-desktop-dockerbuild 2> /dev/null > /dev/null
 if [ $? != 0 ]; then
-    echo "Docker image riot-desktop-builder not found. Have you run yarn run docker:setup?"
+    echo "Docker image riot-desktop-dockerbuild not found. Have you run yarn run docker:setup?"
     exit 1
 fi
 

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -35,6 +35,7 @@ const tray = require('./tray');
 const vectorMenu = require('./vectormenu');
 const webContentsHandler = require('./webcontents-handler');
 const updater = require('./updater');
+const protocolInit = require('./protocol');
 
 const windowStateKeeper = require('electron-window-state');
 const Store = require('electron-store');
@@ -510,6 +511,9 @@ if (!gotLock) {
     console.log('Other instance detected: exiting');
     app.exit();
 }
+
+// do this after we know we are the primary instance of the app
+protocolInit();
 
 // Register the scheme the app is served from as 'standard'
 // which allows things like relative URLs and IndexedDB to

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -34,14 +34,14 @@ module.exports = () => {
         app.setAsDefaultProtocolClient('riot', process.execPath, [app.getAppPath(), ...args]);
     }
 
-    // Protocol handler for macos
-    app.on('open-url', function(ev, url) {
-        ev.preventDefault();
-        processUrl(url);
-    });
-
-    // Protocol handler for win32/Linux
-    if (process.platform !== 'darwin') {
+    if (process.platform === 'darwin') {
+        // Protocol handler for macos
+        app.on('open-url', function(ev, url) {
+            ev.preventDefault();
+            processUrl(url);
+        });
+    } else {
+        // Protocol handler for win32/Linux
         app.on('second-instance', (ev, commandLine) => {
             const url = commandLine[commandLine.length - 1];
             if (!url.startsWith("riot://")) return;

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const {app} = require('electron');
+
+const processUrl = (url) => {
+    if (!global.mainWindow) return;
+    console.log("Handling link: ", url);
+    global.mainWindow.loadURL(url.replace("riot://", "vector://"));
+};
+
+module.exports = () => {
+    // get all args except `hidden` as it'd mean the app would not get focused
+    const args = process.argv.slice(1).filter(arg => arg !== "--hidden" && arg !== "-hidden");
+    if (app.isPackaged) {
+        app.setAsDefaultProtocolClient('riot', process.execPath, args);
+    } else {
+        // special handler for running without being packaged, e.g `electron .` by passing our app path to electron
+        app.setAsDefaultProtocolClient('riot', process.execPath, [app.getAppPath(), ...args]);
+    }
+
+    // Protocol handler for macos
+    app.on('open-url', function(ev, url) {
+        ev.preventDefault();
+        processUrl(url);
+    });
+
+    // Protocol handler for win32/Linux
+    if (process.platform !== 'darwin') {
+        app.on('second-instance', (ev, commandLine) => {
+            const url = commandLine[commandLine.length - 1];
+            if (!url.startsWith("riot://")) return;
+            processUrl(url);
+        });
+    }
+};
+
+

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -24,13 +24,13 @@ const processUrl = (url) => {
 
 module.exports = () => {
     // get all args except `hidden` as it'd mean the app would not get focused
+    // XXX: passing args to protocol handlers only works on Windows,
+    // so unpackaged deep-linking and --profile passing won't work on Mac/Linux
     const args = process.argv.slice(1).filter(arg => arg !== "--hidden" && arg !== "-hidden");
     if (app.isPackaged) {
         app.setAsDefaultProtocolClient('riot', process.execPath, args);
-    } else {
+    } else if (process.platform === 'win32') { // on Mac/Linux this would just cause the electron binary to open
         // special handler for running without being packaged, e.g `electron .` by passing our app path to electron
-        // XXX: passing args to protocol handlers only works on Windows,
-        // so unpackaged (electron .) deep-linking won't work on Mac/Linux
         app.setAsDefaultProtocolClient('riot', process.execPath, [app.getAppPath(), ...args]);
     }
 

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -24,6 +24,7 @@ const processUrl = (url) => {
 
 module.exports = () => {
     // get all args except `hidden` as it'd mean the app would not get focused
+    // XXX: passing args to protocol handlers only works on Windows, so unpackaged deep-linking won't work on Mac/Linux
     const args = process.argv.slice(1).filter(arg => arg !== "--hidden" && arg !== "-hidden");
     if (app.isPackaged) {
         app.setAsDefaultProtocolClient('riot', process.execPath, args);

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -24,12 +24,13 @@ const processUrl = (url) => {
 
 module.exports = () => {
     // get all args except `hidden` as it'd mean the app would not get focused
-    // XXX: passing args to protocol handlers only works on Windows, so unpackaged deep-linking won't work on Mac/Linux
     const args = process.argv.slice(1).filter(arg => arg !== "--hidden" && arg !== "-hidden");
     if (app.isPackaged) {
         app.setAsDefaultProtocolClient('riot', process.execPath, args);
     } else {
         // special handler for running without being packaged, e.g `electron .` by passing our app path to electron
+        // XXX: passing args to protocol handlers only works on Windows,
+        // so unpackaged (electron .) deep-linking won't work on Mac/Linux
         app.setAsDefaultProtocolClient('riot', process.execPath, [app.getAppPath(), ...args]);
     }
 

--- a/src/webcontents-handler.js
+++ b/src/webcontents-handler.js
@@ -198,19 +198,10 @@ function onEditableContextMenu(ev, params) {
 
 module.exports = (webContents) => {
     webContents.on('new-window', onWindowOrNavigate);
-    // XXX: The below now does absolutely nothing because of
-    // https://github.com/electron/electron/issues/8841
-    // Whilst this isn't a security issue since without
-    // node integration and with the sandbox, it should be
-    // no worse than opening the site in Chrome, it obviously
-    // means the user has to restart Riot to make it usable
-    // again (often unintuitive because it minimises to the
-    // system tray). We therefore need to be vigilant about
-    // putting target="_blank" on links in Riot (although
-    // we should generally be doing this anyway since links
-    // navigating you away from Riot in the browser is
-    // also annoying).
-    webContents.on('will-navigate', onWindowOrNavigate);
+    webContents.on('will-navigate', (ev, target) => {
+        if (target.startsWith("vector://")) return;
+        return onWindowOrNavigate(ev, target);
+    });
 
     webContents.on('context-menu', function(ev, params) {
         if (params.linkURL || params.srcURL) {


### PR DESCRIPTION
Requires https://github.com/vector-im/riot-web/pull/12590 & https://github.com/matrix-org/matrix-react-sdk/pull/4158
Fixes https://github.com/vector-im/riot-web/issues/8247

Known issues:
+ Only works for packaged builds on Mac/Linux as we can't specify arguments to send to the executable.
+ Only works for the default `--profile` on Mac/Linux

The above are both limitations of `app.setAsDefaultProtocolClient` `path` and `args` being Windows-only.

All changes from this PR have been backported into riot-web and thus are duplicated in that PR anyone building using the old electron_app setup before it is discarded.