### PR TITLE
Remove the certificate config for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
     "win": {
       "target": {
         "target": "squirrel"
-      },
-      "certificateSubjectName": "New Vector Ltd"
+      }
     },
     "directories": {
       "output": "dist"


### PR DESCRIPTION
We override a lot of the config in our builder so we'll override
this there too, then the riot-desktop repo builds an unsigned
windows app by default rather than erroring if you don't have our
cert installed, which means other people don't have to patch
package.json to build it.