### PR TITLE
Register Mac electron specific Cmd+, shortcut to User Settings

### DIFF
--- a/src/vectormenu.js
+++ b/src/vectormenu.js
@@ -40,6 +40,11 @@ const template = [
             { role: 'zoomin', accelerator: 'CommandOrControl+=' },
             { role: 'zoomout' },
             { type: 'separator' },
+            {
+                label: 'Preferences',
+                accelerator: 'Command+,', // Mac-only accelerator
+                click() { global.mainWindow.webContents.send('preferences'); },
+            },
             { role: 'togglefullscreen' },
             { role: 'toggledevtools' },
         ],


### PR DESCRIPTION
Port of https://github.com/vector-im/riot-web/pull/12800 - requires it to land first to function.