### PR TITLE
electron-main: Immediatelly set the eventIndex variable to null when closing.

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -394,7 +394,7 @@ ipcMain.on('seshat', async function(ev, payload) {
 
         case 'closeEventIndex':
             if (eventIndex !== null) {
-                let index = eventIndex;
+                const index = eventIndex;
                 eventIndex = null;
 
                 try {

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -394,14 +394,16 @@ ipcMain.on('seshat', async function(ev, payload) {
 
         case 'closeEventIndex':
             if (eventIndex !== null) {
+                let index = eventIndex;
+                eventIndex = null;
+
                 try {
-                    await eventIndex.shutdown();
+                    await index.shutdown();
                 } catch (e) {
                     sendError(payload.id, e);
                     return;
                 }
             }
-            eventIndex = null;
             break;
 
         case 'deleteEventIndex':


### PR DESCRIPTION
The react-sdk doesn't await the closing of the event index, this is done
so because of limitations in the lifecycle module. This wasn't a problem
since we used to just set the eventIndex variable to null. Nowadays we
wait for Tantivy to shutdown using a close() method on the index.

To avoid this being called multiple times while we're already closing the
index set the eventIndex variable to null before awaiting.

This fixes https://github.com/vector-im/riot-web/issues/12838.