### PR TITLE
package.json: Bump the required Seshat version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "tar": "^6.0.1"
   },
   "hakDependencies": {
-    "matrix-seshat": "^1.2.0"
+    "matrix-seshat": "^1.3.1"
   },
   "build": {
     "appId": "im.riot.app",


### PR DESCRIPTION
This bump enables getting the number of search hits and should remove
the database locked errors while searching.