### PR TITLE
Update openssl

### DIFF
--- a/hak/matrix-seshat/fetchDeps.js
+++ b/hak/matrix-seshat/fetchDeps.js
@@ -113,7 +113,7 @@ async function getOpenSsl(hakEnv, moduleInfo) {
         haveOpenSslTar = false;
     }
     if (!haveOpenSslTar) {
-        await needle('get', 'https://www.openssl.org/source/openssl-1.1.1d.tar.gz', {
+        await needle('get', 'https://www.openssl.org/source/openssl-1.1.1f.tar.gz', {
             follow: 10,
             output: openSslTarball,
         });


### PR DESCRIPTION
Apparently openssl move tarballs to /old/ once there's a new version
so all the links break. I guess we should detect what the latest version
is and use that. For now, update the URL.