### PR TITLE
package.json: Bump the Seshat version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "tar": "^6.0.1"
   },
   "hakDependencies": {
-    "matrix-seshat": "^1.3.1"
+    "matrix-seshat": "^1.3.2"
   },
   "build": {
     "appId": "im.riot.app",


### PR DESCRIPTION
I know this is likely automatic since it's a minor version bump but making it explicit is always nice.