### PR TITLE
Enable cross-signing / E2EE by default for DM on release

### DIFF
--- a/riot.im/release/config.json
+++ b/riot.im/release/config.json
@@ -23,14 +23,9 @@
         "siteId": 1,
         "policyUrl": "https://matrix.org/legal/riot-im-cookie-policy"
     },
-    "phasedRollOut": {
-        "feature_lazyloading": {
-            "offset": 1539684000000,
-            "period": 604800000
-        }
-    },
     "features": {
-        "feature_lazyloading": "enable"
+        "feature_cross_signing": "enable",
+        "feature_event_indexing": "enable"
     },
     "enable_presence_by_hs_url": {
         "https://matrix.org": false,


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/13178