### PR TITLE
Add a default Linux distribution

### DIFF
--- a/riot.im/release/conf_distributions
+++ b/riot.im/release/conf_distributions
@@ -1,4 +1,11 @@
 Origin: riot.im
+Codename: default
+Architectures: amd64 i386 source
+Components: main
+SignWith: D7B0B66941D01538
+Tracking: minimal
+
+Origin: riot.im
 Suite: oldoldstable
 Codename: jessie
 Architectures: amd64 i386 source


### PR DESCRIPTION
This adds a default Linux distribution which we'll suggest everyone uses going
forward to simplify packaging since the bytes are all the same anyway.

**Note:** This file seems only used by the `mkrepo.sh` script. I have also updated the live list on the packages server.

Part of https://github.com/vector-im/riot-web/issues/13367