### PR TITLE
Add focal to conf_distributions

### DIFF
--- a/riot.im/release/conf_distributions
+++ b/riot.im/release/conf_distributions
@@ -79,3 +79,10 @@ Architectures: amd64 i386 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
+
+Origin: riot.im
+Codename: focal
+Architectures: amd64 i386 source
+Components: main
+SignWith: D7B0B66941D01538
+Tracking: minimal


### PR DESCRIPTION
I haven't done a single thing to test this :upside_down_face: but I was just trying to install the desktop app on Ubuntu 20.04 and it failed because there was no release for focal.

```
grant@arrakis ~> sudo apt update

Ign:5 https://packages.riot.im/debian focal InRelease
Err:6 https://packages.riot.im/debian focal Release
  404  Not Found [IP: 104.26.5.138 443]
Reading package lists... Done
E: The repository 'https://packages.riot.im/debian focal Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

I'm not sure if there is anything else that needs to be done to support this, but thought I'd throw this PR up to get it on your radar.

Signed-off-by: Grant Orndorff <orndorffgrant@gmail.com>