### PR TITLE
Remove Conflicts from riot-desktop

### DIFF
--- a/riot.im/release/control.template
+++ b/riot.im/release/control.template
@@ -5,7 +5,6 @@ Architecture: amd64
 Maintainer: support@riot.im
 Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libappindicator3-1, libsecret-1-0, libsqlcipher0
 Provides: riot-web
-Conflicts: riot-web
 Replaces: riot-web
 Section: net
 Priority: extra


### PR DESCRIPTION
Some early testing suggests removing this will allow the install of the riot-web
transitional package to proceed.

Part of https://github.com/vector-im/riot-web/issues/13509