### PR TITLE
Persist GPG keys for Linux builds via Docker

### DIFF
--- a/scripts/in-docker.sh
+++ b/scripts/in-docker.sh
@@ -14,6 +14,7 @@ docker run --rm -ti \
  -v ${PWD}:/project \
  -v ${PWD}/docker/node_modules:/project/node_modules \
  -v ${PWD}/docker/.hak:/project/.hak \
+ -v ${PWD}/docker/.gnupg:/root/.gnupg \
  -v ~/.cache/electron:/root/.cache/electron \
  -v ~/.cache/electron-builder:/root/.cache/electron-builder \
  riot-desktop-dockerbuild "$@"


### PR DESCRIPTION
Each build command via Docker for Linux builds creates a separate writable layer
from scratch, so anything shared between commands needs to persist on the host.

This adds the container's GPG keys, so that the riot-web GPG key can be
imported in one step and verified in the next.

Fixes https://github.com/vector-im/riot-web/issues/13545