### PR TITLE
Add CI scripts to install and link JS SDK

### DIFF
--- a/scripts/ci/install-deps.sh
+++ b/scripts/ci/install-deps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+scripts/fetchdep.sh matrix-org matrix-js-sdk
+
+pushd matrix-js-sdk
+yarn link
+yarn install $@
+popd
+
+yarn link matrix-js-sdk
+yarn install $@

--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -x
+
+deforg="$1"
+defrepo="$2"
+defbranch="$3"
+
+[ -z "$defbranch" ] && defbranch="develop"
+
+rm -r "$defrepo" || true
+
+clone() {
+    org=$1
+    repo=$2
+    branch=$3
+    if [ -n "$branch" ]
+    then
+        echo "Trying to use $org/$repo#$branch"
+        git clone git://github.com/$org/$repo.git $repo --branch "$branch" --depth 1 && exit 0
+    fi
+}
+
+# Try the PR author's branch in case it exists on the deps as well.
+# If BUILDKITE_BRANCH is set, it will contain either:
+#   * "branch" when the author's branch and target branch are in the same repo
+#   * "author:branch" when the author's branch is in their fork
+# We can split on `:` into an array to check.
+BUILDKITE_BRANCH_ARRAY=(${BUILDKITE_BRANCH//:/ })
+if [[ "${#BUILDKITE_BRANCH_ARRAY[@]}" == "1" ]]; then
+    clone $deforg $defrepo $BUILDKITE_BRANCH
+elif [[ "${#BUILDKITE_BRANCH_ARRAY[@]}" == "2" ]]; then
+    clone ${BUILDKITE_BRANCH_ARRAY[0]} $defrepo ${BUILDKITE_BRANCH_ARRAY[1]}
+fi
+# Try the target branch of the push or PR.
+clone $deforg $defrepo $BUILDKITE_PULL_REQUEST_BASE_BRANCH
+# Try the current branch from Jenkins.
+clone $deforg $defrepo `"echo $GIT_BRANCH" | sed -e 's/^origin\///'`
+# Use the default branch as the last resort.
+clone $deforg $defrepo $defbranch


### PR DESCRIPTION
This installs and links the JS SDK to access ESLint rules and their deps. These
scripts are copied from the React SDK.

Part of https://github.com/vector-im/riot-web/issues/13584
Used by https://github.com/matrix-org/pipelines/pull/64