### PR TITLE
Fix electron context menu copy/save-as

### DIFF
--- a/src/webcontents-handler.js
+++ b/src/webcontents-handler.js
@@ -99,9 +99,8 @@ function onLinkContextMenu(ev, params) {
         }
     }
 
-    // XXX: We cannot easily save a blob from the main process as only the renderer can resolve them so don't give
-    // the user an option to. One possible workaround was using copyImageAt but there was no way of knowing when
-    // the image would be in the clipboard, it depended on its size.
+    // XXX: We cannot easily save a blob from the main process as
+    // only the renderer can resolve them so don't give the user an option to.
     if (params.hasImageContents && !url.startsWith('blob:')) {
         popupMenu.append(new MenuItem({
             label: 'Sa&ve image as...',


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13845

We had a bunch of issues with the copy/save context menus we presented. The above being due to the `showSaveDialog` going async, instead of using the new `showSaveDialogSync` option I opted to switch it and the `fs` calls to async/await.

+ fixes save-as: awaits showSaveDialog
+ fixes save-as of data:// urls: by extracting the buffer from the nativeImage
+ hides the save-as option for blob: urls due to them only existing in the renderer process
+ uses fs.promises.writeFile instead of writeFileSync
+ cleans up the code a little
+ hides context menu for in-app icons like:
![image](https://user-images.githubusercontent.com/2403652/83351214-f0678180-a339-11ea-9cde-048e7321bcd5.png)

I tried to (ab)use the clipboard for save-as on blob URLs and whilst it did work fundamentally, there was no way to accurately get the timing right. There is no way of knowing when `copyImageAt` is done and the clipboard is ready for us to read the image from.
