### PR TITLE
electron-main: Add support to set and get the user version.

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -613,6 +613,30 @@ ipcMain.on('seshat', async function(ev, payload) {
             }
             break;
 
+        case 'setUserVersion':
+            if (eventIndex === null) break;
+            else {
+                try {
+                    await eventIndex.setUserVersion(args[0]);
+                } catch (e) {
+                    sendError(payload.id, e);
+                    return;
+                }
+            }
+            break;
+
+        case 'getUserVersion':
+            if (eventIndex === null) ret = 0;
+            else {
+                try {
+                    ret = await eventIndex.getUserVersion();
+                } catch (e) {
+                    sendError(payload.id, e);
+                    return;
+                }
+            }
+            break;
+
         default:
             mainWindow.webContents.send('seshatReply', {
                 id: payload.id,


### PR DESCRIPTION
The react-sdk side of this can be found at https://github.com/matrix-org/matrix-react-sdk/pull/4788, while the Riot-web side is at https://github.com/vector-im/riot-web/pull/14080.

Requires a Seshat release with https://github.com/matrix-org/seshat/pull/67.