### PR TITLE
electron-main: Skip the reindex if we're going to delete the db anyways.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "tar": "^6.0.1"
   },
   "hakDependencies": {
-    "matrix-seshat": "^2.0.0",
+    "matrix-seshat": "^2.1.0",
     "keytar": "^5.6.0"
   },
   "build": {

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -207,6 +207,14 @@ let eventIndex = null;
 let mainWindow = null;
 global.appQuitting = false;
 
+
+const deleteFolderRecursive = async (p) => {
+    for (const entry of await afs.readdir(p)) {
+        const curPath = path.join(p, entry);
+        await afs.unlink(curPath);
+    }
+};
+
 // handle uncaught errors otherwise it displays
 // stack traces in popup dialogs, which is terrible (which
 // it will do any time the auto update poke fails, and there's
@@ -453,7 +461,22 @@ ipcMain.on('seshat', async function(ev, payload) {
                             const recoveryIndex = new SeshatRecovery(eventStorePath, {
                                 passphrase: seshatPassphrase,
                             });
-                            await recoveryIndex.reindex();
+
+                            const userVersion = await recoveryIndex.getUserVersion();
+
+                            // If our user version is 0 we'll delete the db
+                            // anyways so reindexing it is a waste of time.
+                            if (userVersion === 0) {
+                                await recoveryIndex.shutdown();
+
+                                try {
+                                    await deleteFolderRecursive(eventStorePath);
+                                } catch (e) {
+                                }
+                            } else {
+                                await recoveryIndex.reindex();
+                            }
+
                             eventIndex = new Seshat(eventStorePath, {
                                 passphrase: seshatPassphrase,
                             });
@@ -485,13 +508,6 @@ ipcMain.on('seshat', async function(ev, payload) {
 
         case 'deleteEventIndex':
             {
-                const deleteFolderRecursive = async (p) => {
-                    for (const entry of await afs.readdir(p)) {
-                        const curPath = path.join(p, entry);
-                        await afs.unlink(curPath);
-                    }
-                };
-
                 try {
                     await deleteFolderRecursive(eventStorePath);
                 } catch (e) {

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -208,7 +208,7 @@ let mainWindow = null;
 global.appQuitting = false;
 
 
-const deleteFolderRecursive = async (p) => {
+const deleteContents = async (p) => {
     for (const entry of await afs.readdir(p)) {
         const curPath = path.join(p, entry);
         await afs.unlink(curPath);
@@ -470,7 +470,7 @@ ipcMain.on('seshat', async function(ev, payload) {
                                 await recoveryIndex.shutdown();
 
                                 try {
-                                    await deleteFolderRecursive(eventStorePath);
+                                    await deleteContents(eventStorePath);
                                 } catch (e) {
                                 }
                             } else {
@@ -509,7 +509,7 @@ ipcMain.on('seshat', async function(ev, payload) {
         case 'deleteEventIndex':
             {
                 try {
-                    await deleteFolderRecursive(eventStorePath);
+                    await deleteContents(eventStorePath);
                 } catch (e) {
                 }
             }


### PR DESCRIPTION
This requires a Seshat release with https://github.com/matrix-org/seshat/pull/69 so we can check the user version from a recovery database.