### PR TITLE
Add new spinner labs option to config.json

### DIFF
--- a/riot.im/nightly/config.json
+++ b/riot.im/nightly/config.json
@@ -14,6 +14,7 @@
     "hosting_signup_link": "https://modular.im/services/matrix-hosting-riot?utm_source=riot-web&utm_medium=web",
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",
     "features": {
+        "feature_new_spinner": "labs",
         "feature_pinning": "labs",
         "feature_custom_status": "labs",
         "feature_custom_tags": "labs",


### PR DESCRIPTION
Previously added to Riot Web's /develop config.json here: https://github.com/vector-im/riot-web/pull/14213