### PR TITLE
Remove ' (Riot)' from app name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "element-desktop",
-  "productName": "Element (Riot)",
+  "productName": "Element",
   "main": "src/electron-main.js",
   "version": "1.7.1",
   "description": "A feature-rich client for Matrix.org",

--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -115,18 +115,16 @@ if (userDataPathInProtocol) {
 } else if (argv['profile-dir']) {
     userDataPath = argv['profile-dir'];
 } else {
-    // strip the bracketed riot suffix from the app name, if any: we don't want to
-    // store user data in a dir with that transitional suffix.
-    const appName = app.getName().replace(' (Riot)', '');
-
-    // always override the user data path because electron uses the ${appData}/productName
-    // but we want our productName to be "Element (Riot)" for a transition period after the rename.
-    let newUserDataPath = path.join(app.getPath('appData'), appName);
+    let newUserDataPath = app.getPath('userData');
     if (argv['profile']) {
         newUserDataPath += '-' + argv['profile'];
     }
     const newUserDataPathExists = isRealUserDataDir(newUserDataPath);
-    const oldUserDataPath = path.join(app.getPath('appData'), appName.replace('Element', 'Riot'));
+    let oldUserDataPath = path.join(app.getPath('appData'), app.getName().replace('Element', 'Riot'));
+    if (argv['profile']) {
+        oldUserDataPath += '-' + argv['profile'];
+    }
+
     const oldUserDataPathExists = isRealUserDataDir(oldUserDataPath);
     console.log(newUserDataPath + " exists: " + (newUserDataPathExists ? 'yes' : 'no'));
     console.log(oldUserDataPath + " exists: " + (oldUserDataPathExists ? 'yes' : 'no'));


### PR DESCRIPTION
And remove the hacks to make the user data path different from the
app name. Also add the profile dir to the legacy user data dir too.

Fixes https://github.com/vector-im/riot-web/issues/14619
Fixes https://github.com/vector-im/riot-web/issues/14623